### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 Kiwix's backup companion
-===
+========================
 
-A [docker image](https://hub.docker.com/r/kiwix/borg-backup) to easily backup your services' data into [BorgBase](https://www.borgbase.com/).
+A [Docker image](https://hub.docker.com/r/kiwix/borg-backup) to easily backup your services' data into [BorgBase](https://www.borgbase.com/).
 
 ## What's this?
 
-This tool is a docker image that you launch along your other docker services, sharing the data volume with it (read-only).
+This tool is a Docker image that you launch along your other Docker services, sharing the data volume with it (read-only).
 
 Example:
 
@@ -16,7 +16,7 @@ docker run -v /data/www:/var/www/html -d nginx
 docker run -v /data/www:/storage:ro kiwix/borg-backup backup --name nginx --every 1h
 ```
 
-In this example, the content of `/data/www` on the host will be securely backed-up to BorgBase, in **append-only** mode, every hour.
+In this example, the content of `/data/www` on the host will be securely backed-up to BorgBase every hour.
 
 ## How it works
 
@@ -24,59 +24,60 @@ There are three main components to this tool:
 
 - [BorgBase](https://www.borgbase.com/) is an affordable backup hosting service. We use it to store encrypted backups. You can use the free plan which is limited to two repositories or use a paid plan.
 - [Bitwarden](https://bitwarden.com/) is a secured password management service. We only use features from the free plan.
-- [Borg](https://www.borgbackup.org/) is an OSS backup tool that creates and transmits encrypted backups.
+- [Borg](https://www.borgbackup.org/) is an FOSS backup tool that creates and transmits encrypted backups.
 
-In borgbase, everything revolves around the concept of a *repo*. It's a place (~folder) in which your data goes (encrypted). For every *datasource* that you want to backup, you'll have one borgbase repo and one companion container.
+In BorgBase, everything revolves around the concept of a *repository*. It's a place (~folder) in which your data goes (encrypted). For every *datasource* that you want to backup, you'll have one BorgBase repository and one companion container.
 
-This tool generates an SSH keypair for your repo, configures borgbase to allow backups using this key (append-only) and stores the keypair in your bitwarden account so you don't have to worry much about credentials.
+This tool generates an SSH keypair for your repo, configures BorgBase to allow backups using this key (with *append-only* restriction) and stores the keypair in your Bitwarden account so you don't have to worry much about credentials.
 
 ## What do I need?
 
-* One Borgbase account (free or paid)
-* Two bitwarden accounts (a master one and a read-only one)
+* Mandatory: One BorgBase account (free or paid)
+* Mandatory: A Bitwarden accounts (a *master*)
+* Optional: A second Bitwarden account (a *backuper* one without the credential to create/read BorgBase repositories)
 
-### Accounts setup
+### Accounts setup (to do once)
 
 This is the annoying part. You'll have to manually create a couple of accounts and do some manipulations. This is a one-time thing, no matter how many repos you'll setup.
 
-#### Borgbase
+#### BorgBase
 
-1. Create an account at [borgbase](https://www.borgbase.com/register) (or reuse one)
+1. Create an account at [BorgBase](https://www.borgbase.com/register) (or reuse one)
 1. Once logged it, go to [Acounts » API](https://www.borgbase.com/account?tab=2) then **New Token**.
 1. Choose a name (`kiwix-backup`?) and make sure you select **Create only** (important!)
-1. Securely keep a reference to that created Token, you'll need that every time you setup a new repo.
+1. Securely keep a reference to that created token, you'll need that every time you setup a new repository.
 
 #### Bitwarden
 
-In order to store what we need in bitwarden (SSH keypairs, borgbase token) but without exposing our bitwarden token to the backup companion, we'll use two different accounts:
+In order to store what we need in Bitwarden (SSH keypairs, BorgBase token) but without exposing our Bitwarden token to the backup companion, we'll use two different accounts:
 
 - one that is used solely to setup repo. That's the *master* account.
-- one that is used when backing-up. this one will have read-only access to the items in the vault.
+- one that is used when backing-up. This *backuper* one will have read-only access to the items in the vault.
 
-**Note**: using two accounts is safer but it doesn't mean the read-only account should be considered public. Keep it safe!
+**Note**: You can use only one account if you want. But using two accounts is safer. That said, it doesn't mean the read-only account should be considered public. Keep it safe!
 
-1. Create one master bitwarden account (email/password)
+1. Create one master Bitwarden account (email/password)
 1. Create an *Organization* from that account's UI
 1. Create a single *Collection* to be shared accross this organization
 1. Invite a member to this organization, with:
- - the email adress you'll use to create that second bitwarden account in a minute
+ - the email adress you'll use to create that second Bitwarden account in a minute
  - choosing `User` mode
  - choising `selected-collections only`
  - check the collection you created earlier
  - check `read-only` (but not hide password)
-1. using the invitation link your received on that email address, create one backup bitwarden account (email/password)
-1. login to bitwarden UI using master account and confirm membership
+1. using the invitation link your received on that email address, create one backup Bitwarden account (email/password)
+1. login to Bitwarden UI using master account and confirm membership
 
 ## Usage
 
-Every *repo* or service you want to backup needs to be initialized once before you start backing-up your data.
-This is a quick step that is separated from the backup one in order to keep your *master* bitwarden credentials from being moved around.
+Every *repository* or service you want to backup needs to be initialized once before you start backing-up your data.
+This is a quick step that is separated from the backup one in order to keep your *master* Bitwarden credentials from being moved around.
 
 ### Setting up
 
 This command is intended to be run from your local machine so you don't have to insert your credentials on any other system.
 
-This tool is **interactive** and will ask for your bitwarden master password and your borgbase token (both you should have created in *Accounts setup*).
+This tool is **interactive** and will ask for your Bitwarden master password and your BorgBase token (both you should have created in *Accounts setup*).
 
 ```sh
 docker run -it kiwix/borg-backup setup-new-repo \
@@ -89,16 +90,16 @@ docker run -it kiwix/borg-backup setup-new-repo \
 
 #### Choosing a repo-name
 
-We suggest you use reverse-FQDN notation for your repo names as the bitwarden matching is done using a *search* query meaning that if you have two repos named `my-service` and `my-service2`, the first one will fail, receiving two results instead of one.
+We suggest you use reverse-FQDN notation for your repo names as the Bitwarden matching is done using a *search* query meaning that if you have two repositories named `my-service` and `my-service2`, the first one will fail, receiving two results instead of one.
 
 
 **Optional values**:
 
-- `<nb-days>`: periodicity of Borgbase e-mail alert in day(s) (default : `1`)
+- `<nb-days>`: periodicity of BorgBase e-mail alert in day(s) (default : `1`)
 - `<max-storage>`:  quota in MB (default: no quota)
-- `<region>`: borgbase server region (`eu` or `us`) (default : `eu`)
+- `<region>`: BorgBase server region (`eu` or `us`) (default : `eu`)
 
-That's it. You should now have a *repo* ready to receive backups.
+That's it. You should now have a *repoitory* ready to receive backups.
 
 ### Backing-up
 
@@ -111,10 +112,10 @@ docker run -v <some-folder>:/storage:ro \
     kiwix/borg-backup backup --name <repo-name> --every <period>
 ```
 
-- `<repo-name>` is the *repo* name configured in the setup step.
+- `<repo-name>` is the *repository* name configured in the setup step.
 - `<period>` is the interval to launch backup on: units are `m` for minutes (`1-30`), `h` for hours (`1-30`), `d` for days (`1-14`), `M` for months (`1-6`).
 
-Other parameters can be configured via docker environment variables:
+Other parameters can be configured via Docker environment variables:
 
 - Retention options:
   - `KEEP_WITHIN`: keep all archives less than this old (no used by default)
@@ -161,7 +162,7 @@ This will extract the content of the archive into `/restore` (which you should h
 
 As your backup as just regular borg backups, you can follow [these docs](https://docs.borgbase.com/restore/) to restore your data manually.
 
-Restoring requires your SSH keypair stored in bitwarden. In your bitwarden vault, you'll find one item for each of your *repo*. In this item, you'll find:
+Restoring requires your SSH keypair stored in bitwarden. In your Bitwarden vault, you'll find one item for each of your *repository*. In this item, you'll find:
 
 - `username`: that's your SSH public key. Save it as `~/.ssh/<myrepo>.pub`
 - `password`: that's your SSH private key. Save it as `~/.ssh/<myrepo>`
@@ -198,19 +199,19 @@ Yes, beside the `all` trick mentionned above, if you need to backup a list of da
 
 No, at the moment, we use their API so it can't be replaced with another service.
 
-### What if my bitwarden is compromised?
+### What if my Bitwarden is compromised?
 
-Don't panic! If your read-only bitwarden credentials are compromised, you won't loose any data:
+Don't panic! If your read-only Bitwarden credentials are compromised, you won't loose any data:
 
-- bitwarden items can't be modified by this account
-- the SSH keypairs stored in bitwarden are now compromised but it can only do much on borgbase:
-  - create new repo (check and delete those if that happened)
-  - append new data to your repos (but cannot delete those you backed-up)
+- Bitwarden items can't be modified by this account
+- The SSH keypairs stored in Bitwarden are now compromised but it can only do much on BorgBase:
+    - append new data to your repos (but cannot delete those you backed-up)
+    - read backuped data (check and delete those if that happened)
 
-You should now manually remove the keypairs from borgbase and remove post-incident archives from your repo (read [this documentation on append-only](https://docs.borgbase.com/faq/#append-only-mode) first).
+You should now manually remove the keypairs from BorgBase and remove post-incident archives from your repo (read [this documentation on append-only](https://docs.borgbase.com/faq/#append-only-mode) first).
 
-### Can I use a single bitwarden account?
+### Can I use a single Bitwarden account?
 
 Yes, but we highly discourage it.
 
-The sole account is thus the read-write one (*master*) and it means it it gets compromised, one could delete items from your bitwarden account. As your SSH keypairs are only stored in bitwarden, loosing them mean you won't be able to retrieve nor decrypt your backups.
+The sole account is thus the read-write one (*master*) and it means it it gets compromised, one could delete items from your Bitwarden account. As your SSH keypairs are only stored in Bitwarden, loosing them mean you won't be able to retrieve nor decrypt your backups.


### PR DESCRIPTION
Light modifications. But we need to clarify about what can exactly happen if the `read-only` Bitwarden account is compromised. With it, it should not be able to create new accoutns. The Borgbase TOKEN should never be known by the backuper.