### PR TITLE
Add support for archive-content listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,19 @@ docker run \
     -e BW_CLIENTID=<bitwarden-readonly-apikey-clientid> \
     -e BW_CLIENTSECRET=<bitwarden-readonly-apikey-secret> \
     -e BW_PASSWORD=<bitwarden-readonly-password> \
+    ghcr.io/kiwix/borg-backup restore --name <repo-name> --list "<archive-name>"
+```
+
+This will list the content of the archive with size, date and ownership for each file.
+
+`--list` accepts a special value of `latest` that lists the lasted archive from the list.
+
+```sh
+docker run \
+    -v /data/temp:/restore:rw \
+    -e BW_CLIENTID=<bitwarden-readonly-apikey-clientid> \
+    -e BW_CLIENTSECRET=<bitwarden-readonly-apikey-secret> \
+    -e BW_PASSWORD=<bitwarden-readonly-password> \
     ghcr.io/kiwix/borg-backup restore --name <repo-name> --extract "<archive-name>"
 ```
 

--- a/bin/restore
+++ b/bin/restore
@@ -61,7 +61,7 @@ then
     exit 2
 fi
 
-repo_location=$(python3 -c 'from ruamel.yaml import YAML ; print(YAML().load(open("/root/.config/borgmatic/config.yaml"))["location"]["repositories"][0])')
+repo_location=$(/app/kiwix-python/bin/python3 -c 'from ruamel.yaml import YAML ; print(YAML().load(open("/root/.config/borgmatic/config.yaml"))["location"]["repositories"][0])')
 
 if [ "$list" = true ]
 then

--- a/bin/restore
+++ b/bin/restore
@@ -27,6 +27,7 @@ case $key in
     shift # past value
     ;;
     -l|--list)
+    archive="$2"
     list=true
     shift # past argument
     shift # past value
@@ -64,8 +65,19 @@ repo_location=$(python3 -c 'from ruamel.yaml import YAML ; print(YAML().load(ope
 
 if [ "$list" = true ]
 then
-    echo -e "\n\nList avaible archives ..."
-    borg list "$repo_location"
+    if [ -z $archive ]
+    then
+        echo -e "\n\nList avaible archives ..."
+        borg list "$repo_location"
+    else
+        if [ $archive = latest ]
+        then
+            echo "Find the latest archive ..."
+            archive=$(borg list "$repo_location" | tail -n1 | cut -d' '  -f1)
+        fi
+        echo -e "\n\nList content of archive ${archive}…"
+        borg list "${repo_location}::${archive}"
+    fi
 fi
 
 if [ "$extract" = true ]


### PR DESCRIPTION
`restore --list` only offered archives listing but being able to check the content of an archive before restoring it is very important. For large backups, using `--extract` on dev's machine is not useful.

By simply accepting optional archive ID on `--list` we can support both and it's quite convenient.

Usage:

```sh
restore --name kiwix-archive-downloads --list "kiwix-archive-downloads__backup__2026-06-01T00:03:38"
# or
restore --name kiwix-archive-downloads --list latest
```